### PR TITLE
#8 Ignore unknown record types for now, update @throws doc

### DIFF
--- a/src/Entities/DNSRecordCollection.php
+++ b/src/Entities/DNSRecordCollection.php
@@ -85,6 +85,9 @@ class DNSRecordCollection extends EntityAbstract implements \ArrayAccess, \Itera
         return $this->records->offsetGet($offset);
     }
 
+    /**
+     * @throws \RemotelyLiving\PHPDNS\Exceptions\InvalidArgumentException
+     */
     public function offsetSet($offset, $value): void
     {
         if (!$value instanceof DNSRecord) {

--- a/src/Entities/DNSRecordType.php
+++ b/src/Entities/DNSRecordType.php
@@ -59,10 +59,13 @@ class DNSRecordType extends EntityAbstract
      */
     private $type;
 
+    /**
+     * @throws \RemotelyLiving\PHPDNS\Exceptions\InvalidArgumentException
+     */
     public function __construct(string $type)
     {
         if (!in_array($type, self::VALID_TYPES, true)) {
-            throw new InvalidArgumentException("{$type} is not a valid DNS query type");
+            throw new InvalidArgumentException("{$type} is not an existing DNS record type");
         }
 
         $this->type = $type;
@@ -73,8 +76,15 @@ class DNSRecordType extends EntityAbstract
         return $this->type;
     }
 
+    /**
+     * @throws \RemotelyLiving\PHPDNS\Exceptions\InvalidArgumentException
+     */
     public static function createFromInt(int $code) : DNSRecordType
     {
+        if (!isset(self::CODE_TYPE_MAP[$code])) {
+            throw new InvalidArgumentException("{$code} is not able to be mapped to an existing DNS record type");
+        }
+
         return new static(self::CODE_TYPE_MAP[$code]);
     }
 

--- a/src/Entities/DataAbstract.php
+++ b/src/Entities/DataAbstract.php
@@ -14,6 +14,9 @@ abstract class DataAbstract implements Arrayable, Serializable
         return (string)$this === (string)$dataAbstract;
     }
 
+    /**
+     * @throws \RemotelyLiving\PHPDNS\Exceptions\InvalidArgumentException
+     */
     public static function createFromTypeAndString(DNSRecordType $recordType, string $data): self
     {
         if ($recordType->isA(DNSRecordType::TYPE_TXT)) {

--- a/src/Entities/Hostname.php
+++ b/src/Entities/Hostname.php
@@ -10,6 +10,9 @@ class Hostname extends EntityAbstract
      */
     private $hostname;
 
+    /**
+     * @throws \RemotelyLiving\PHPDNS\Exceptions\InvalidArgumentException
+     */
     public function __construct(string $hostname)
     {
         $hostname = $this->normalizeHostName($hostname);

--- a/src/Entities/IPAddress.php
+++ b/src/Entities/IPAddress.php
@@ -10,6 +10,9 @@ class IPAddress extends EntityAbstract
      */
     private $IPAddress;
 
+    /**
+     * @throws \RemotelyLiving\PHPDNS\Exceptions\InvalidArgumentException
+     */
     public function __construct(string $IPAddress)
     {
         $IPAddress = trim($IPAddress);

--- a/src/Resolvers/GoogleDNS.php
+++ b/src/Resolvers/GoogleDNS.php
@@ -72,12 +72,15 @@ class GoogleDNS extends ResolverAbstract
         return $this->mapResults($this->mapper, $results);
     }
 
+    /**
+     * @throws \RemotelyLiving\PHPDNS\Resolvers\Exceptions\QueryFailure
+     */
     private function doApiQuery(array $query = []): array
     {
         try {
             $response = $this->http->request('GET', '/resolve?' . http_build_query($query));
         } catch (RequestException $e) {
-            throw new QueryFailure("Unable to query CloudFlare API", 0, $e);
+            throw new QueryFailure("Unable to query GoogleDNS API", 0, $e);
         }
 
         $result = (array) json_decode((string)$response->getBody(), true);

--- a/src/Resolvers/ResolverAbstract.php
+++ b/src/Resolvers/ResolverAbstract.php
@@ -70,6 +70,9 @@ abstract class ResolverAbstract implements ObservableResolver
             ->has($record);
     }
 
+    /**
+     * @throws \RemotelyLiving\PHPDNS\Resolvers\Exceptions\QueryFailure
+     */
     public function getRecords(string $hostname, string $recordType = null): DNSRecordCollection
     {
         $recordType = DNSRecordType::createFromString($recordType ?? 'ANY');
@@ -119,5 +122,8 @@ abstract class ResolverAbstract implements ObservableResolver
         return $collection;
     }
 
+    /**
+     * @throws \RemotelyLiving\PHPDNS\Resolvers\Exceptions\QueryFailure
+     */
     abstract protected function doQuery(Hostname $hostname, DNSRecordType $recordType): DNSRecordCollection;
 }

--- a/src/Services/LocalSystemDNS.php
+++ b/src/Services/LocalSystemDNS.php
@@ -7,6 +7,9 @@ use \RemotelyLiving\PHPDNS\Services\Interfaces\LocalSystemDNS as LocalSystemDNSI
 
 final class LocalSystemDNS implements LocalSystemDNSInterface
 {
+    /**
+     * @throws \RemotelyLiving\PHPDNS\Resolvers\Exceptions\QueryFailure
+     */
     public function getRecord(string $hostname, int $type): array
     {
         $results = @dns_get_record($hostname, $type);
@@ -21,6 +24,9 @@ final class LocalSystemDNS implements LocalSystemDNSInterface
         return $results;
     }
 
+    /**
+     * @throws \RemotelyLiving\PHPDNS\Resolvers\Exceptions\ReverseLookupFailure
+     */
     public function getHostnameByAddress(string $IPAddress): string
     {
         $hostname = @gethostbyaddr($IPAddress);

--- a/tests/Unit/Entities/DNSRecordTypeTest.php
+++ b/tests/Unit/Entities/DNSRecordTypeTest.php
@@ -9,7 +9,7 @@ class DNSRecordTypeTest extends BaseTestAbstract
     /**
      * @test
      */
-    public function hasConvenientFactoryMethods()
+    public function hasConvenientNamedFactoryMethods()
     {
         foreach (DNSRecordType::VALID_TYPES as $type) {
             $function = DNSRecordType::class . "::create{$type}";
@@ -23,9 +23,18 @@ class DNSRecordTypeTest extends BaseTestAbstract
      * @test
      * @expectedException \RemotelyLiving\PHPDNS\Exceptions\InvalidArgumentException
      */
-    public function onlyAllowsValidTypes()
+    public function onlyAllowsValidTypesFromStrings()
     {
         DNSRecordType::createFromString('SDFSF');
+    }
+
+    /**
+     * @test
+     * @expectedException \RemotelyLiving\PHPDNS\Exceptions\InvalidArgumentException
+     */
+    public function onlyAllowsValidTypesFromIntCodes()
+    {
+        DNSRecordType::createFromInt(-100);
     }
 
     /**


### PR DESCRIPTION
Addresses #8 

When ResolverAbstract::mapResults() is called it will skip anything with invalid arguments, but log the information, so throwing should be good enough for now.