### PR TITLE
Update spatie/dns to support PHP 8.1

### DIFF
--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0']
+        php-versions: ['7.4', '8.0', '8.1']
     name: PHP ${{ matrix.php-versions }} Test on Ubuntu
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/event-dispatcher": "^6.0 || ^5.0 || ^4.0 || ^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "guzzlehttp/promises": "^1.3",
-        "spatie/dns": "^1.5"
+        "spatie/dns": "^1.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"


### PR DESCRIPTION
To enable the usage of this package in PHP 8.1, the spatie/dns package needs to be updated to at least version 1.6.

I made the following changes:
- Update the spatie/dns package to 1.6
- Add PHP 8.1 as version to run the tests on
- Remove deprecated vimeo configuration