### PR TITLE
Add 3rd parameter to getRecords to optionally skip filtering records

### DIFF
--- a/src/Resolvers/ResolverAbstract.php
+++ b/src/Resolvers/ResolverAbstract.php
@@ -85,7 +85,7 @@ abstract class ResolverAbstract implements ObservableResolver
     /**
      * @throws \RemotelyLiving\PHPDNS\Resolvers\Exceptions\QueryFailure
      */
-    public function getRecords(string $hostname, string $recordType = null): DNSRecordCollection
+    public function getRecords(string $hostname, string $recordType = null, bool $filterRecords = true): DNSRecordCollection
     {
         $recordType = DNSRecordType::createFromString($recordType ?? 'ANY');
         $hostname = Hostname::createFromString($hostname);
@@ -94,7 +94,7 @@ abstract class ResolverAbstract implements ObservableResolver
         $profile->startTransaction();
 
         try {
-            $result = ($recordType->equals(DNSRecordType::createANY()))
+            $result = ($recordType->equals(DNSRecordType::createANY()) || $filterRecords === false)
                 ? $this->doQuery($hostname, $recordType)
                 : $this->doQuery($hostname, $recordType)->filteredByType($recordType);
         } catch (QueryFailure $e) {


### PR DESCRIPTION
Fix for #53 

Adds a 3rd parameter to getRecords to optionally skip filtering records.
Backwards compatible with the original code.

This allows a lookup for any kind of record type (for example `TXT`) to also return `CNAME` records. This is consistent with how `dig` also returns records.