### PR TITLE
Upgrade guzzle/promises to ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "psr/cache": "^1.0 || ^2.0",
         "symfony/event-dispatcher": "^6.0 || ^5.0 || ^4.0 || ^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "guzzlehttp/promises": "^1.3",
+        "guzzlehttp/promises": "^2.0",
         "spatie/dns": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
guzzle/promises 1.x is deprecated, and the only reason to keep using it is for php 7 compatibility. Given the fact that this library has a requirement of php >= 8.0 and does not use any guzzle/promises-features directly, this change should be without any problems.
